### PR TITLE
https://github.com/redhat-gpe/bxms_process_automation_foundations/iss…

### DIFF
--- a/ansible/roles/ocp-workload-bxms-pam/defaults/main.yml
+++ b/ansible/roles/ocp-workload-bxms-pam/defaults/main.yml
@@ -27,7 +27,9 @@ deploy_status_delay: 20
 
 kie_admin_passwd: test1234!
 
-MAVEN_REPO_URL: http://nexus3.default.svc.cluster.local:8081/repository/maven-public/
+# dtorresf: default for user cloudforms provision, when using for workshop use the -e MAVEN_REPO_URL option to override during playbook execution
+# value for workshop cluster: http://nexus3.default.svc.cluster.local:8081/repository/maven-public/
+MAVEN_REPO_URL: http://nexus.opentlc-shared:8081/repository/maven-public/
 
 POSTGRESQL_IMAGE_STREAM_TAG: 9.5
 pam_tag: 1.2-3


### PR DESCRIPTION
…ues/28

https://github.com/redhat-gpe/bxms_process_automation_foundations/issues/28
Default for user cloudforms provision, when using for workshop use the -e MAVEN_REPO_URL option to override during playbook execution. Value for workshop cluster: http://nexus3.default.svc.cluster.local:8081/repository/maven-public/